### PR TITLE
use opencv module to make voronoi diagram of isoheights

### DIFF
--- a/BTile.yaml
+++ b/BTile.yaml
@@ -358,7 +358,7 @@ styles:
                             st.x = (worldPos.x-XMIN)/(XMAX-XMIN);
                             st.y = (worldPos.y-YMIN)/(YMAX-YMIN);
                             vec3 color = texture2D(u_terrain, st).rgb;
-                            return -12000.0+color.g*65025.+color.b*255.;
+                            return -32768.+color.g*65025.+color.b*255.;
                         } else {
                             return 0.0;
                         }

--- a/README.md
+++ b/README.md
@@ -309,19 +309,19 @@ You should install the following Python modules:
 - PIL
 
 ```bash
-pip install pil
+sudo pip install pil
 ```
 
 - [Requests](http://docs.python-requests.org/en/latest/user/install/#install)
 
 ```bash
-pip install requests
+sudo pip install requests
 ```
 
 - NumPy:
 
 ```bash
-pip install numpy
+sudo pip install numpy
 ```
 
 - OpenCV for python:
@@ -334,7 +334,7 @@ sudo apt-get install python-opencv
 
 ```bash
 sudo apt-get install libgeos++
-pip install shapely 
+sudo pip install shapely 
 ```
 
 If you are going to make A tiles (the first approach, described at the top of this post) you should also install [GDAL](https://www.mapbox.com/tilemill/docs/guides/gdal/).

--- a/data/makeATiles.py
+++ b/data/makeATiles.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
-# Author: Patricio Gonzalez Vivo - 2015 (@patriciogv)
+# Authors: 
+# 	- Patricio Gonzalez Vivo (@patriciogv)
+#	- Kevin Kreiser (@kevinkreiser)
 # Thanks to Derek Watkins ( @dwtkns ) for collectiong the data 
 # and making it easy to use in this project http://dwtkns.com/srtm30m/
 

--- a/data/makeBTiles.py
+++ b/data/makeBTiles.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 
-# Author: Patricio Gonzalez Vivo -height_range 2015 (@patriciogv)
+# Authors: 
+# 	- Patricio Gonzalez Vivo (@patriciogv)
+#	- Kevin Kreiser (@kevinkreiser)
+#
 import sys
 from terrarium import getPointsOfID, makeTile, makeTilesOfPoints
 from common import getStringRangeToArray

--- a/data/outfile.xml
+++ b/data/outfile.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<osm version="0.6" generator="CGImap 0.4.0 (5216 thorn-01.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
+<osm version="0.6" generator="CGImap 0.4.0 (8690 thorn-02.openstreetmap.org)" copyright="OpenStreetMap and contributors" attribution="http://www.openstreetmap.org/copyright" license="http://opendatacommons.org/licenses/odbl/1-0/">
  <node id="31807195" visible="true" version="3" changeset="12291412" timestamp="2012-07-18T18:01:55Z" user="OSMF Redaction Account" uid="722137" lat="37.8321335" lon="-122.4734939"/>
  <node id="31815480" visible="true" version="4" changeset="12291412" timestamp="2012-07-18T18:01:54Z" user="OSMF Redaction Account" uid="722137" lat="37.8263547" lon="-122.4861611"/>
  <node id="31824973" visible="true" version="4" changeset="12291412" timestamp="2012-07-18T18:01:53Z" user="OSMF Redaction Account" uid="722137" lat="37.8257894" lon="-122.4823105"/>

--- a/data/terrarium.py
+++ b/data/terrarium.py
@@ -147,16 +147,18 @@ def makeHeighmap(path, name, size, points, heights):
     (facets, centers) = subdiv.getVoronoiFacetList([])
 
     # an image where we will rasterize the voronoi cells
-    image = numpy.zeros((size, size, 1), dtype = 'int16')
+    image = numpy.zeros((size, size, 3), dtype = 'uint8')
     for i in xrange(0, len(facets)):
         ifacet_arr = []
         for f in facets[i]:
             ifacet_arr.append(f)
         ifacet = numpy.array(ifacet_arr, numpy.int)
-        # the color is the height at the voronoi cite for this cell
-        color = (point_heights[(centers[i][0], centers[i][1])])
+        # the color is the height at the voronoi cite for this cell, offset to bring to unsigned 16bits
+        height = point_heights[(centers[i][0], centers[i][1])] + 32768
+        # to back them into a standard texture we split the high and low order bytes, note the order is G B R
+        color = (int(math.floor(height % 255)), int(math.floor(height / 255) % 255), 0)
         # we exploit the fact that voronoi cells are convex polygons for faster rasterization
-        cv2.fillConvexPoly(img, ifacet, color, cv2.CV_AA, 0)
+        cv2.fillConvexPoly(image, ifacet, color, cv2.CV_AA, 0)
 
     # we'll keep the result here
     cv2.imwrite(path + '/' + name + '.png', image)

--- a/data/terrarium.py
+++ b/data/terrarium.py
@@ -2,6 +2,7 @@
 
 import requests, json, math, os, sys
 import numpy
+import cv2
 from scipy.spatial import Delaunay
 from PIL import Image
 import xml.etree.ElementTree as ET
@@ -124,47 +125,41 @@ def getTrianglesFromPoints(P):
     return triangles
 
 # Given a set of points and height of the same lenght compose a voronoi PNG image
-def makeHeighmap(path, name, size, height_range, points, heights):
-    bbox = getBoundingBox(points)
+def makeHeighmap(path, name, size, points, heights):
+    # bail if it doesnt look write
     total_samples = len(points)
     if total_samples != len(heights):
-        print("Length don't match")
+        print("Lengths don't match")
         return
-    
-    image = Image.new("RGB", (int(size), int(size)))
-    putpixel = image.putpixel
-    imgx, imgy = image.size
-    nx = []
-    ny = []
-    nr = []
-    ng = []
-    nb = []
 
-    # Make samples data
+    # convert mercator to pixels and map pixels to height values
+    bbox = getBoundingBox(points)
+    point_heights = {}
     for i in range(total_samples):
-        nx.append(remap(points[i][0], bbox[0], bbox[1], 0, imgx))
-        ny.append(remap(points[i][1], bbox[2], bbox[3], imgy, 0))
+        x = remap(points[i][0], bbox[0], bbox[1], 0, size))
+        y = remap(points[i][1], bbox[2], bbox[3], size, 0))
+        point_heights[(x, y)] = heights[i]
 
-        elev_unsigned = int(12000+heights[i])
-        nr.append(int(0))
-        ng.append(int(math.floor(elev_unsigned/255)%255))
-        nb.append(int(math.floor(elev_unsigned%255)))
+    # subdivision from opencv, can do voronoi and its dual the delaunay triangulation
+    subdiv = cv2.Subdiv2D((0, 0, size, size))
+    for k, v in point_heights.iteritems():
+        subdiv.insert(v)
+    (facets, centers) = subdiv.getVoronoiFacetList([])
 
-    # Compute Voronoi (one-to-all)
-    # TODO:
-    #   - Improve this... is very expensive 
-    for y in range(imgy):
-        for x in range(imgx):
-            dmin = math.hypot(imgx-1, imgy-1)
-            j = -1
-            for i in range(total_samples):
-                d = math.hypot(nx[i]-x, ny[i]-y)
-                if d < dmin:
-                    dmin = d
-                    j = i
-            putpixel((x, y), (nr[j], ng[j], nb[j]))
+    # an image where we will rasterize the voronoi cells
+    image = numpy.zeros((size, size, 1), dtype = 'int16')
+    for i in xrange(0, len(facets)):
+        ifacet_arr = []
+        for f in facets[i]:
+            ifacet_arr.append(f)
+        ifacet = numpy.array(ifacet_arr, numpy.int)
+        # the color is the height at the voronoi cite for this cell
+        color = (point_heights[(centers[i][0], centers[i][1])])
+        # we exploit the fact that voronoi cells are convex polygons for faster rasterization
+        cv2.fillConvexPoly(img, ifacet, color, cv2.CV_AA, 0)
 
-    image.save(path+'/'+name+".png", "PNG")
+    # we'll keep the result here
+    cv2.imwrite(path + '/' + name + '.png', image)
 
 # Given a set of points return a valid 
 def getPolygonFromPoints(points):
@@ -260,7 +255,7 @@ def makeTile(path, lng, lat, zoom, doPNGs):
         heights = getElevationFromPoints(points_latlon)
         heights = getEquilizedHeightByGroup(heights, groups)
         heights_range = getRange(heights)
-        makeHeighmap(path, name, ELEVATION_RASTER_TILE_SIZE, heights_range, points_merc, heights)
+        makeHeighmap(path, name, ELEVATION_RASTER_TILE_SIZE, points_merc, heights)
 
 # Return all the points of a given OSM ID
 def getPointsOfID (osmID):

--- a/data/terrarium.py
+++ b/data/terrarium.py
@@ -136,8 +136,8 @@ def makeHeighmap(path, name, size, points, heights):
     bbox = getBoundingBox(points)
     point_heights = {}
     for i in range(total_samples):
-        x = remap(points[i][0], bbox[0], bbox[1], 0, size)
-        y = remap(points[i][1], bbox[2], bbox[3], size, 0)
+        x = remap(points[i][0], bbox[0], bbox[1], 0, size - 1)
+        y = remap(points[i][1], bbox[2], bbox[3], size - 1, 0)
         point_heights[(x, y)] = heights[i]
 
     # subdivision from opencv, can do voronoi and its dual the delaunay triangulation

--- a/data/terrarium.py
+++ b/data/terrarium.py
@@ -136,8 +136,8 @@ def makeHeighmap(path, name, size, points, heights):
     bbox = getBoundingBox(points)
     point_heights = {}
     for i in range(total_samples):
-        x = remap(points[i][0], bbox[0], bbox[1], 0, size - 1)
-        y = remap(points[i][1], bbox[2], bbox[3], size - 1, 0)
+        x = int(remap(points[i][0], bbox[0], bbox[1], 0, size - 1))
+        y = int(remap(points[i][1], bbox[2], bbox[3], size - 1, 0))
         point_heights[(x, y)] = heights[i]
 
     # subdivision from opencv, can do voronoi and its dual the delaunay triangulation

--- a/data/terrarium.py
+++ b/data/terrarium.py
@@ -142,8 +142,8 @@ def makeHeighmap(path, name, size, points, heights):
 
     # subdivision from opencv, can do voronoi and its dual the delaunay triangulation
     subdiv = cv2.Subdiv2D((0, 0, size, size))
-    for k, v in point_heights.iteritems():
-        subdiv.insert(v)
+    for p in point_heights.iterkeys():
+        subdiv.insert(p)
     (facets, centers) = subdiv.getVoronoiFacetList([])
 
     # an image where we will rasterize the voronoi cells


### PR DESCRIPTION
so to properly display buildings without messing up their rooftops its nice to have an isoheight underneath them. @patriciogonzalezvivo added this by computing the brute force voronoi diagram where the cites were the building vertices, if i understand correctly. he mentioned though that the algorithm was very slow for complex scenes.

so here we let opencv do the heavy work. it has methods which likely use a variant of fortunes algorithm to compute the voronoi diagram (and its dual the delaunay triangulation) in O(nlogn) time. this is way faster than brute force.

another nice thing it does is allow us to rasterize the voronoi cells into a png fairly quickly. we do this by exploiting the fact that voronoi cells are always convex.